### PR TITLE
企業画面（イベント登録画面）の仮UI作成

### DIFF
--- a/lib/auth/provider/schedule_provider.dart
+++ b/lib/auth/provider/schedule_provider.dart
@@ -1,0 +1,12 @@
+import 'package:riverpod/riverpod.dart';
+
+final startDateProvider = StateProvider<String>((ref) {
+  final nowDate = DateTime.now();
+  return '${nowDate.year}年${nowDate.month}月${nowDate.day}日';
+});
+
+
+final endDateProvider = StateProvider<String>((ref) {
+  final nowDate = DateTime.now();
+  return '${nowDate.year}年${nowDate.month}月${nowDate.day}日';
+});

--- a/lib/auth/provider/text_count_provider.dart
+++ b/lib/auth/provider/text_count_provider.dart
@@ -1,0 +1,4 @@
+import 'package:riverpod/riverpod.dart';
+
+
+final textCountProvider = StateProvider<String>((ref) => '');

--- a/lib/view/company_screen/children/company_industry_drop_down_button.dart
+++ b/lib/view/company_screen/children/company_industry_drop_down_button.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intern_trip/auth/provider/industry_provider.dart';
+
+final List<String> industries = [
+  '指定なし',
+  'IT・通信',
+  'メーカー（機械・電気）',
+  'メーカー（素材・化学・食品）',
+  'メーカー（医療・薬品）',
+  'メーカー（その他）',
+  '建設',
+  '不動産',
+  '医療・薬品',
+  '金融',
+  'コンサルティングリサーチ',
+  '広告',
+  'メディア',
+  '総合商社',
+  '専門商社',
+  '人材',
+  '教育',
+  '運輸・物流',
+  '小売',
+  'エネルギー',
+  '農林水産・鉱山',
+  'その他',
+];
+
+class CompanyIndustriesDropDownButton extends ConsumerWidget {
+  const CompanyIndustriesDropDownButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    String industryDropdownValue = ref.watch(industryProvider);
+
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: Colors.black12,
+      ),
+      width: MediaQuery.of(context).size.width * 0.9,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.factory,
+              size: 40,
+            ),
+            const SizedBox(width: 8),
+            DropdownButton(
+              icon: const SizedBox(),
+              underline: const SizedBox(),
+              value: industryDropdownValue,
+              items: industries.map<DropdownMenuItem<String>>(
+                (String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(
+                      value,
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  );
+                },
+              ).toList(),
+              onChanged: (String? value) {
+                ref.read(industryProvider.notifier).state = value!;
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/company_screen/children/company_occupation_drop_down_button.dart
+++ b/lib/view/company_screen/children/company_occupation_drop_down_button.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intern_trip/auth/provider/occupation_provider.dart';
+
+final List<String> occupations = [
+  '指定なし',
+  '研究開発職',
+  '設計・開発職（メカ・部品等）',
+  '生産技術・工法開発・生産管理職',
+  '品質管理・メンテナンス',
+  'システムエンジニア',
+  '組み込み開発エンジニア',
+  'AIエンジニア',
+  'データサイエンティスト',
+  'Webエンジニア',
+  'ネットワーク/インフラエンジニア',
+  'セキュリティエンジニア',
+  'システム運用・保守',
+  '建築設計',
+  'プラントエンジニア',
+  '知的財産部門',
+  'その他技術色',
+  '技術営業（セールスエンジニア）',
+  'ゲーム系エンジニア',
+  'Webプロデューサー・ディレクター',
+  'Webデザイナー・UI/UXデザイナー',
+  'コンサルタント',
+  '金融専門職',
+  'マーケティング・商品企画',
+  '総合職',
+  '企画・管理',
+  '営業',
+  '医師',
+  '看護師',
+  '歯科医',
+  '薬剤師',
+  '医療技師（臨床検査技師など）',
+  'その他',
+];
+
+class CompanyOccupationDropDownButton extends ConsumerWidget {
+  const CompanyOccupationDropDownButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    String occupationDropdownValue = ref.watch(occupationProvider);
+
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black12,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      width: MediaQuery.of(context).size.width * 0.9,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.work,
+              size: 40,
+            ),
+            const SizedBox(width: 5),
+            DropdownButton(
+              icon: const SizedBox(),
+              underline: const SizedBox(),
+              value: occupationDropdownValue,
+              items: occupations.map<DropdownMenuItem<String>>(
+                (String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(
+                      value,
+                      style: const TextStyle(fontSize: 16),
+                      maxLines: 3,
+                    ),
+                  );
+                },
+              ).toList(),
+              onChanged: (String? value) {
+                ref.read(occupationProvider.notifier).state = value!;
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/company_screen/children/company_text_form_field.dart
+++ b/lib/view/company_screen/children/company_text_form_field.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+class CompanyTextFormField extends StatelessWidget {
+  final TextEditingController textEditingController;
+
+  const CompanyTextFormField({
+    super.key,
+    required this.textEditingController,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width * 0.9,
+      height: 50,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: Colors.black12,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 18.0),
+        child: TextFormField(
+          controller: textEditingController,
+          decoration: const InputDecoration(
+            border: InputBorder.none,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/company_screen/children/event_content_text_form_field.dart
+++ b/lib/view/company_screen/children/event_content_text_form_field.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intern_trip/auth/provider/text_count_provider.dart';
+
+class EventContentTextFormField extends ConsumerWidget {
+  final TextEditingController textEditingController;
+
+  const EventContentTextFormField({
+    super.key,
+    required this.textEditingController,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final textCount = ref.watch(textCountProvider);
+    return Container(
+      width: MediaQuery.of(context).size.width * 0.9,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: Colors.black12,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: TextFormField(
+          controller: textEditingController,
+          keyboardType: TextInputType.multiline,
+          maxLines: null,
+          onChanged: (value) {
+            ref.read(textCountProvider.notifier).state = value;
+          },
+          decoration: InputDecoration(
+            border: InputBorder.none,
+            counterText: '${textCount.length}字',
+            counterStyle: const TextStyle(fontSize: 16),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/company_screen/children/schedule_picker.dart
+++ b/lib/view/company_screen/children/schedule_picker.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intern_trip/auth/provider/schedule_provider.dart';
+
+class SchedulePicker extends ConsumerWidget {
+  const SchedulePicker({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final startDate = ref.watch(startDateProvider);
+    final endDate = ref.watch(endDateProvider);
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black12,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      width: MediaQuery.of(context).size.width * 0.9,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.date_range_outlined,
+              size: 40,
+            ),
+            TextButton(
+              onPressed: () => _selectStartDate(context, ref),
+              child: Text(
+                startDate,
+                style: const TextStyle(fontSize: 14),
+              ),
+            ),
+            const Text(
+              '〜',
+              style: TextStyle(fontSize: 14),
+            ),
+            TextButton(
+              onPressed: () => _selectEndDate(context, ref),
+              child: Text(
+                endDate,
+                style: const TextStyle(fontSize: 14),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _selectStartDate(BuildContext context, WidgetRef ref) async {
+    final DateTime? selected = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime(2022),
+      lastDate: DateTime(2023),
+    );
+    if (selected != null) {
+      final startDate = '${selected.year}年${selected.month}月${selected.day}日';
+      ref.read(startDateProvider.notifier).state = startDate;
+    }
+  }
+
+  Future<void> _selectEndDate(BuildContext context, WidgetRef ref) async {
+    final DateTime? selected = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime(2022),
+      lastDate: DateTime(2023),
+    );
+    if (selected != null) {
+      final endDate = '${selected.year}年${selected.month}月${selected.day}日';
+      ref.read(endDateProvider.notifier).state = endDate;
+    }
+  }
+}

--- a/lib/view/company_screen/children/venue_drop_down_button.dart
+++ b/lib/view/company_screen/children/venue_drop_down_button.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intern_trip/auth/provider/goal_provider.dart';
+
+final List<String> prefectures = [
+  '北海道',
+  '青森県',
+  '秋田県',
+  '岩手県',
+  '山形県',
+  '宮城県',
+  '新潟県',
+  '福島県',
+  '栃木県',
+  '群馬県',
+  '茨城県',
+  '千葉県',
+  '神奈川県',
+  '埼玉県',
+  '東京都',
+  '山梨県',
+  '長野県',
+  '富山県',
+  '岐阜県',
+  '静岡県',
+  '石川県',
+  '愛知県',
+  '福井県',
+  '京都府',
+  '滋賀県',
+  '三重県',
+  '奈良県',
+  '大阪府',
+  '和歌山県',
+  '兵庫県',
+  '鳥取県',
+  '島根県',
+  '岡山県',
+  '広島県',
+  '山口県',
+  '香川県',
+  '徳島県',
+  '愛知県',
+  '高知県',
+  '福岡県',
+  '佐賀県',
+  '長崎県',
+  '大分県',
+  '熊本県',
+  '宮崎県',
+  '鹿児島県',
+  '沖縄県'
+];
+
+class VenueDropDownButton extends ConsumerWidget {
+  const VenueDropDownButton({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    String dropdownValue = ref.watch(goalProvider);
+    return Container(
+      decoration: BoxDecoration(
+        color: Colors.black12,
+        borderRadius: BorderRadius.circular(10),
+      ),
+      width: MediaQuery.of(context).size.width * 0.9,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16.0),
+        child: Row(
+          children: [
+            const Icon(
+              Icons.airplanemode_active,
+              size: 40,
+            ),
+            const SizedBox(width: 5),
+            DropdownButton(
+              icon: const SizedBox(),
+              underline: const SizedBox(),
+              value: dropdownValue,
+              items: prefectures.map<DropdownMenuItem<String>>(
+                (String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(
+                      value,
+                      style: const TextStyle(fontSize: 16),
+                    ),
+                  );
+                },
+              ).toList(),
+              onChanged: (String? value) {
+                ref.read(goalProvider.notifier).state = value!;
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/company_screen/company_screen.dart
+++ b/lib/view/company_screen/company_screen.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intern_trip/view/common_widgets/common_button.dart';
+import 'package:intern_trip/view/company_screen/children/company_industry_drop_down_button.dart';
+import 'package:intern_trip/view/company_screen/children/company_occupation_drop_down_button.dart';
+import 'package:intern_trip/view/company_screen/children/schedule_picker.dart';
+import 'package:intern_trip/view/company_screen/children/company_text_form_field.dart';
+import 'package:intern_trip/view/company_screen/children/event_content_text_form_field.dart';
+import 'package:intern_trip/view/company_screen/children/venue_drop_down_button.dart';
+
+class CompanyScreen extends ConsumerWidget {
+  const CompanyScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final TextEditingController companyController = TextEditingController();
+    final TextEditingController eventNameController = TextEditingController();
+    final TextEditingController eventContentController =
+        TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('イベント登録'),
+      ),
+      body: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 50),
+              const Text(
+                '企業名',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              CompanyTextFormField(
+                textEditingController: companyController,
+              ),
+              const SizedBox(height: 32),
+              const Text(
+                'イベント名',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              CompanyTextFormField(
+                textEditingController: eventNameController,
+              ),
+              const SizedBox(height: 32),
+              const Text(
+                'イベント内容',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              EventContentTextFormField(
+                  textEditingController: eventContentController),
+              const SizedBox(height: 32),
+              const Text(
+                '業種',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const CompanyIndustriesDropDownButton(),
+              const SizedBox(height: 32),
+              const Text(
+                '職種',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const CompanyOccupationDropDownButton(),
+              const SizedBox(height: 32),
+              const Text(
+                '開催地',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const VenueDropDownButton(),
+              const SizedBox(height: 32),
+              const Text(
+                '開催日時',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 18,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const SchedulePicker(),
+              const SizedBox(height: 64),
+              CommonButton(title: 'イベントを登録', onPush: () {}),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/view/home_screen/children/departure_date_picker.dart
+++ b/lib/view/home_screen/children/departure_date_picker.dart
@@ -11,7 +11,7 @@ class DepartureDatePicker extends ConsumerWidget {
     return Container(
       decoration: const BoxDecoration(
           border: Border(bottom: BorderSide(color: Colors.black38))),
-      width: MediaQuery.of(context).size.width * 0.85,
+      width: MediaQuery.of(context).size.width * 0.9,
       child: Row(
         children: [
           const Icon(

--- a/lib/view/home_screen/children/goal_drop_down_button.dart
+++ b/lib/view/home_screen/children/goal_drop_down_button.dart
@@ -66,7 +66,7 @@ class GoalDropDownButton extends ConsumerWidget {
           ),
         ),
       ),
-      width: MediaQuery.of(context).size.width * 0.85,
+      width: MediaQuery.of(context).size.width * 0.9,
       child: Row(
         children: [
           const Icon(
@@ -77,6 +77,7 @@ class GoalDropDownButton extends ConsumerWidget {
           const Text('目的地：　', style: TextStyle(fontSize: 16)),
           const SizedBox(width: 5),
           DropdownButton(
+            icon: const SizedBox(),
             underline: const SizedBox(),
             value: dropdownValue,
             items: prefectures.map<DropdownMenuItem<String>>(

--- a/lib/view/home_screen/children/industry_drop_down_button.dart
+++ b/lib/view/home_screen/children/industry_drop_down_button.dart
@@ -5,15 +5,15 @@ import 'package:intern_trip/auth/provider/industry_provider.dart';
 final List<String> industries = [
   '指定なし',
   'IT・通信',
-  'メーカー（機械・\n電気）',
-  'メーカー（素材・\n化学・食品）',
-  'メーカー（医療・\n薬品）',
+  'メーカー（機械・電気）',
+  'メーカー（素材・化学・食品）',
+  'メーカー（医療・薬品）',
   'メーカー（その他）',
   '建設',
   '不動産',
   '医療・薬品',
   '金融',
-  'コンサルティング\nリサーチ',
+  'コンサルティングリサーチ',
   '広告',
   'メディア',
   '総合商社',
@@ -26,7 +26,6 @@ final List<String> industries = [
   '農林水産・鉱山',
   'その他',
 ];
-
 
 class IndustriesDropDownButton extends ConsumerWidget {
   const IndustriesDropDownButton({Key? key}) : super(key: key);
@@ -43,8 +42,12 @@ class IndustriesDropDownButton extends ConsumerWidget {
           ),
         ),
       ),
-      width: MediaQuery.of(context).size.width * 0.85,
-      child: SizedBox(
+      width: MediaQuery.of(context).size.width * 0.9,
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white12,
+          borderRadius: BorderRadius.circular(10),
+        ),
         child: Row(
           children: [
             const Icon(
@@ -54,23 +57,26 @@ class IndustriesDropDownButton extends ConsumerWidget {
             const SizedBox(width: 5),
             const Text('業種：　', style: TextStyle(fontSize: 16)),
             const SizedBox(width: 5),
-            DropdownButton(
-              underline: const SizedBox(),
-              value: industryDropdownValue,
-              items: industries.map<DropdownMenuItem<String>>(
-                (String value) {
-                  return DropdownMenuItem<String>(
-                    value: value,
-                    child: Text(
-                      value,
-                      style: const TextStyle(fontSize: 16),
-                    ),
-                  );
+            Center(
+              child: DropdownButton(
+                icon: const SizedBox(),
+                underline: const SizedBox(),
+                value: industryDropdownValue,
+                items: industries.map<DropdownMenuItem<String>>(
+                  (String value) {
+                    return DropdownMenuItem<String>(
+                      value: value,
+                      child: Text(
+                        value,
+                        style: const TextStyle(fontSize: 14),
+                      ),
+                    );
+                  },
+                ).toList(),
+                onChanged: (String? value) {
+                  ref.read(industryProvider.notifier).state = value!;
                 },
-              ).toList(),
-              onChanged: (String? value) {
-                ref.read(industryProvider.notifier).state = value!;
-              },
+              ),
             ),
           ],
         ),

--- a/lib/view/home_screen/children/occupation_drop_down_button.dart
+++ b/lib/view/home_screen/children/occupation_drop_down_button.dart
@@ -5,28 +5,28 @@ import 'package:intern_trip/auth/provider/occupation_provider.dart';
 final List<String> occupations = [
   '指定なし',
   '研究開発職',
-  '設計・開発職（メカ・\n部品等）',
-  '生産技術・工法開発・\n生産管理職',
+  '設計・開発職（メカ・部品等）',
+  '生産技術・工法開発・生産管理職',
   '品質管理・メンテナンス',
   'システムエンジニア',
-  '組み込み開発\nエンジニア',
+  '組み込み開発エンジニア',
   'AIエンジニア',
   'データサイエンティスト',
   'Webエンジニア',
-  'ネットワーク/\nインフラエンジニア',
+  'ネットワーク/インフラエンジニア',
   'セキュリティエンジニア',
   'システム運用・保守',
   '建築設計',
   'プラントエンジニア',
   '知的財産部門',
   'その他技術色',
-  '技術営業\n（セールスエンジニア）',
+  '技術営業（セールスエンジニア）',
   'ゲーム系エンジニア',
-  'Webプロデューサー・\nディレクター',
-  'Webデザイナー・\nUI/UXデザイナー',
+  'Webプロデューサー・ディレクター',
+  'Webデザイナー・UI/UXデザイナー',
   'コンサルタント',
   '金融専門職',
-  'マーケティング・\n商品企画',
+  'マーケティング・商品企画',
   '総合職',
   '企画・管理',
   '営業',
@@ -34,7 +34,7 @@ final List<String> occupations = [
   '看護師',
   '歯科医',
   '薬剤師',
-  '医療技師\n（臨床検査技師など）',
+  '医療技師（臨床検査技師など）',
   'その他',
 ];
 
@@ -47,13 +47,12 @@ class OccupationDropDownButton extends ConsumerWidget {
 
     return Container(
       decoration: const BoxDecoration(
-        border: Border(
-          bottom: BorderSide(
-            color: Colors.black38,
-          ),
-        )
-      ),
-      width: MediaQuery.of(context).size.width*0.85,
+          border: Border(
+        bottom: BorderSide(
+          color: Colors.black38,
+        ),
+      )),
+      width: MediaQuery.of(context).size.width * 0.9,
       child: Row(
         children: [
           const Icon(
@@ -64,15 +63,16 @@ class OccupationDropDownButton extends ConsumerWidget {
           const Text('職種：　', style: TextStyle(fontSize: 16)),
           const SizedBox(width: 5),
           DropdownButton(
+            icon: const SizedBox(),
             underline: const SizedBox(),
             value: occupationDropdownValue,
             items: occupations.map<DropdownMenuItem<String>>(
-                  (String value) {
+              (String value) {
                 return DropdownMenuItem<String>(
                   value: value,
                   child: Text(
                     value,
-                    style: const TextStyle(fontSize: 16),
+                    style: const TextStyle(fontSize: 14),
                     maxLines: 3,
                   ),
                 );

--- a/lib/view/start_screen/start_screen.dart
+++ b/lib/view/start_screen/start_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intern_trip/view/company_screen/company_screen.dart';
 import 'package:intern_trip/view/start_screen/login_screen/login_screen.dart';
 import 'package:intern_trip/view/start_screen/sign_up_screen/sign_up_screen.dart';
 import 'package:lottie/lottie.dart';
@@ -51,6 +52,22 @@ class StartScreen extends StatelessWidget {
                   },
                   child: const Center(
                     child: Text('ログイン'),
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: MediaQuery.of(context).size.width * 0.7,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => CompanyScreen(),
+                      ),
+                    );
+                  },
+                  child: const Center(
+                    child: Text('企業側ログイン'),
                   ),
                 ),
               ),


### PR DESCRIPTION
## 概要
企業側が利用するイベント登録画面の仮UIを作成した

## 内容
- 企業名・イベント名を入力するTextFormFieldの作成
- イベント内容を入力するTextFormFieldの作成
- 業種を選択するドロップダウンボタンの作成
- 職種を選択するドロップダウンボタンの作成
- 開催地を選択するドロップダウンボタンの作成
- 開催地日時を選択するデータピッカーの作成
- イベント内容を入力するTextFormFieldの文字数を管理するプロバイダの作成
- 開催日時を管理するプロバイダの作成

## スクリーンショット
| iOS | Android |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone 13 - 2022-12-12 at 13 24 18](https://user-images.githubusercontent.com/39763423/206960517-10a4503a-596d-45b8-b292-9e26fd86bb7c.png) | ![Screenshot_1670819125](https://user-images.githubusercontent.com/39763423/206960551-511beced-54c4-4796-9745-620ee82d073d.png) | 
| ![Simulator Screen Shot - iPhone 13 - 2022-12-12 at 13 24 28](https://user-images.githubusercontent.com/39763423/206960582-07116046-9922-4ef6-aa09-8f1c1fb72d1d.png) | ![Screenshot_1670819128](https://user-images.githubusercontent.com/39763423/206960612-81a9ab8a-bcb9-4584-99e0-2aba4786162b.png) |


