### PR TITLE
企業側のログイン・新規登録画面の仮UIの作成

### DIFF
--- a/lib/utils/constants.dart
+++ b/lib/utils/constants.dart
@@ -1,0 +1,4 @@
+enum UserType{
+  user,
+  company,
+}

--- a/lib/view/start_screen/login_screen/login_screen.dart
+++ b/lib/view/start_screen/login_screen/login_screen.dart
@@ -1,13 +1,20 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intern_trip/auth/provider/input_user_provider.dart';
-import 'package:intern_trip/data_models/auth_user.dart';
+import 'package:intern_trip/utils/constants.dart';
 import 'package:intern_trip/view/common_widgets/common_button.dart';
 import 'package:intern_trip/view/home_screen/home_screen.dart';
 import 'package:intern_trip/view/start_screen/children/auth_text_form_field.dart';
+import 'package:intern_trip/view/start_screen/sign_up_screen/sign_up_screen.dart';
 import 'package:lottie/lottie.dart';
 
 class LoginScreen extends ConsumerWidget {
+  final UserType userType;
+
+  LoginScreen({
+    super.key,
+    required this.userType,
+  });
+
   // buildメソッドで定義すると、入力内容が消える
   final TextEditingController _idController = TextEditingController();
   final TextEditingController _passController = TextEditingController();
@@ -56,9 +63,35 @@ class LoginScreen extends ConsumerWidget {
                 onPush: () => {
                   // ref.read(inputUserProvider.notifier).state =
                   //     AuthUser(id: _idController.text, pass: _passController.text);
-                  Navigator.push(context, MaterialPageRoute(builder: (_) => HomeScreen()))
+                  Navigator.push(
+                      context, MaterialPageRoute(builder: (_) => HomeScreen()))
                 },
               ),
+              Center(
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width * 0.7,
+                  child: (userType == UserType.company)
+                      ? ElevatedButton(
+                          onPressed: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => SignUpScreen(
+                                  userType: UserType.company,
+                                ),
+                              ),
+                            );
+                          },
+                          child: const Center(
+                            child: Text(
+                              '新規登録はこちら',
+                              style: TextStyle(fontSize: 16),
+                            ),
+                          ),
+                        )
+                      : const SizedBox(),
+                ),
+              )
             ],
           ),
         ),

--- a/lib/view/start_screen/sign_up_screen/sign_up_screen.dart
+++ b/lib/view/start_screen/sign_up_screen/sign_up_screen.dart
@@ -1,18 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:intern_trip/auth/functions/create_account.dart';
+import 'package:intern_trip/utils/constants.dart';
 import 'package:intern_trip/view/common_widgets/common_button.dart';
 import 'package:intern_trip/view/start_screen/children/auth_text_form_field.dart';
 import 'package:lottie/lottie.dart';
 
 class SignUpScreen extends StatelessWidget {
-  SignUpScreen({Key? key}) : super(key: key);
+  final UserType userType;
+
+  SignUpScreen({
+    super.key,
+    required this.userType,
+  });
+
   // buildメソッドで定義すると、入力内容が消える
   final TextEditingController _idController = TextEditingController();
   final TextEditingController _passController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       body: SafeArea(
         child: SingleChildScrollView(
@@ -43,7 +49,6 @@ class SignUpScreen extends StatelessWidget {
                 title: 'メールアドレス',
                 controller: _idController,
               ),
-
               const SizedBox(height: 30),
               authTextFormField(
                 title: 'パスワード',
@@ -53,10 +58,13 @@ class SignUpScreen extends StatelessWidget {
               const SizedBox(height: 50),
               CommonButton(
                   title: '登録',
-                  onPush: () => createAccount(
-                        _idController.text,
-                        _passController.text,
-                      )),
+                  onPush: () {
+                    // TODO ユーザータイプによってメソッドを切り替える
+                    createAccount(
+                      _idController.text,
+                      _passController.text,
+                    );
+                  }),
             ],
           ),
         ),

--- a/lib/view/start_screen/start_screen.dart
+++ b/lib/view/start_screen/start_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:intern_trip/utils/constants.dart';
 import 'package:intern_trip/view/company_screen/company_screen.dart';
 import 'package:intern_trip/view/start_screen/login_screen/login_screen.dart';
 import 'package:intern_trip/view/start_screen/sign_up_screen/sign_up_screen.dart';
@@ -30,7 +31,7 @@ class StartScreen extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (context) => SignUpScreen(),
+                        builder: (context) => SignUpScreen(userType: UserType.user,),
                       ),
                     );
                   },
@@ -46,7 +47,7 @@ class StartScreen extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => LoginScreen(),
+                        builder: (_) => LoginScreen(userType: UserType.user,),
                       ),
                     );
                   },
@@ -62,7 +63,7 @@ class StartScreen extends StatelessWidget {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                        builder: (_) => CompanyScreen(),
+                        builder: (_) => LoginScreen(userType: UserType.company,),
                       ),
                     );
                   },


### PR DESCRIPTION
## 概要
ユーザ側で利用したログイン画面・新規登録画面を活用し、企業側でも利用できるように修正を加えた

## 内容
- 新規登録画面・ログイン画面において、ユーザ側か企業側か識別できるようにenumクラスを作成
- ログイン画面において、企業側ログイン画面から遷移した場合に表示するボタンを作成

## スクリーンショット

| 企業側ログイン画面 | ユーザ側ログイン画面 |
| ---- | ---- |
| ![Simulator Screen Shot - iPhone 13 - 2022-12-12 at 19 22 28](https://user-images.githubusercontent.com/39763423/207021846-bd6c5594-692a-4f14-8137-ec8587cf69a3.png) | ![Simulator Screen Shot - iPhone 13 - 2022-12-12 at 19 22 34](https://user-images.githubusercontent.com/39763423/207021904-5b74c85c-bcfe-4a76-86bd-34db3839a215.png) |

